### PR TITLE
Added request timout option

### DIFF
--- a/source/Client.php
+++ b/source/Client.php
@@ -42,6 +42,11 @@ final class Client {
     private $privateKey = '';
 
     /**
+     * @var int request timeout, seconds
+     */
+    private $timeout = 10;
+
+    /**
      * @param string $publicKey public application key
      * @param string $privateKey private application key
      */
@@ -259,8 +264,18 @@ final class Client {
      * @return Request request instance for API call
      */
     private function getRequest($method, $parameters, $ResponseBuilder) {
-        $Request = new Request($method, $ResponseBuilder, $parameters);
+        $Request = new Request($method, $ResponseBuilder, $parameters, $this->timeout);
         $Request->sign($this->publicKey, $this->privateKey);
         return $Request;
+    }
+
+    /**
+     * Set request timeout
+     * @param int $timeout seconds
+     * @return $this
+     */
+    public function setTimeout($timeout) {
+        $this->timeout = (int) $timeout;
+        return $this;
     }
 }

--- a/source/Request.php
+++ b/source/Request.php
@@ -50,6 +50,11 @@ final class Request {
     private $ResponseBuilder = null;
 
     /**
+     * @var int request timeout, seconds
+     */
+    private $timeout = 0;
+
+    /**
      * @var array map that store relations between API and HTTP methods for requests
      */
     private static $methodMap = [
@@ -66,11 +71,13 @@ final class Request {
      * @param string $method API method name
      * @param Closure $ResponseBuilder
      * @param array $parameters method call parameters
+     * @param int $timeout request timeout, seconds
      */
-    public function __construct($method, Closure $ResponseBuilder, array $parameters = []) {
+    public function __construct($method, Closure $ResponseBuilder, array $parameters = [], $timeout = 10) {
         $this->method          = (string) $method;
         $this->parameters      = $parameters;
         $this->ResponseBuilder = $ResponseBuilder;
+        $this->timeout         = (int) $timeout;
     }
 
     /**
@@ -114,7 +121,7 @@ final class Request {
         $HttpRequest->setTransport(HttpRequest::TRANSPORT_CURL);
         $HttpRequest->setUrl(self::ENDPOINT_URI)
             ->setConnectTimeout(1)
-            ->setTimeout(10)
+            ->setTimeout($this->timeout)
             ->addUrlField($this->method)
             ->setMethod(self::$methodMap[$this->method]);
         $this->appendParameters($HttpRequest);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -338,6 +338,18 @@ final class ClientTest extends PHPUnit_Framework_TestCase {
         ], $this->getRequestParametersProperty($Request));
     }
 
+    public function testRequestTimeout() {
+        $timeout = 60;
+        $Client = new Client('pub_key', 'private_key');
+        $Client->setTimeout($timeout);
+
+        $Class = new ReflectionClass(Client::class);
+        $PropertyParameters = $Class->getProperty('timeout');
+        $PropertyParameters->setAccessible(true);
+
+        $this->assertEquals($timeout, $PropertyParameters->getValue($Client));
+    }
+
     /**
      * Get request parameters for request instance
      * @param Request $Request request instance

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -152,4 +152,15 @@ final class RequestTest extends PHPUnit_Framework_TestCase {
             'param2' => 'value2',
         ], $HttpRequest->getGetData());
     }
+
+    public function testRequestTimout() {
+        $timeout = 60;
+        $Request = new Request('card/processRecurring', function() {}, [], $timeout);
+
+        $Class = new ReflectionClass(Request::class);
+        $PropertyParameters = $Class->getProperty('timeout');
+        $PropertyParameters->setAccessible(true);
+
+        $this->assertEquals($timeout, $PropertyParameters->getValue($Request));
+    }
 }


### PR DESCRIPTION
Sometimes PaymentNinja can wait more than 10 seconds before return payment method api result.
```
exception 'alxmsl\Network\Exception\CurlErrorException' with message 'Operation timed out after 10001 milliseconds with 0 bytes received' in /var/www/project/vendor/alxmsl/network/source/Http/CurlTransport.php:101
Stack trace:
#0 /var/www/project/vendor/alxmsl/network/source/Http/Request.php(109): alxmsl\Network\Http\CurlTransport->makeHttpRequest(Object(alxmsl\Network\Http\Request))
#1 /var/www/project/vendor/alxmsl/paymentninjaclient/source/Request.php(102): alxmsl\Network\Http\Request->send()
```

